### PR TITLE
fix: switch to manual embed for codepen

### DIFF
--- a/src/libs/viblo-embed/index.js
+++ b/src/libs/viblo-embed/index.js
@@ -5,11 +5,17 @@ const isValidProvider = (name = '') => {
     return !!name.toLowerCase().match(/(youtube|vimeo|slideshare|codepen|gist|jsfiddle|googleslide|viblo)/)
 }
 
-const render = (url, provider) => Promise.resolve(
-    oembed.isOembed(url, provider)
-        ? oembed.render(url, provider)
-        : manual.render(url, provider)
-)
+const render = (url, provider) => {
+    if (oembed.isCodepenEmbed(url)) {
+        return manual.render(url, 'codepen')
+    }
+
+    if (oembed.isOembed(url, provider)) {
+        return oembed.render(url, provider)
+    }
+
+    return manual.render(url, provider)
+}
 
 export default {
     render,

--- a/src/libs/viblo-embed/manual/parsers/codepen.js
+++ b/src/libs/viblo-embed/manual/parsers/codepen.js
@@ -1,0 +1,16 @@
+export default (url) => {
+    const regex = /^https?:\/\/codepen.io\/([a-zA-Z0-9]+)\/(pen|embed\/preview|embed)\/([a-zA-Z0-9]+)(.*)$/
+    const matches = url.match(regex)
+
+    if (!matches) return
+
+    const penUser = matches[1]
+    const penId = matches[3]
+    const penOptions = matches[4]
+
+    const embedURL = `https://codepen.io/${penUser}/embed/${penId}${penOptions}`
+
+    return {
+        src: embedURL,
+    }
+}

--- a/src/libs/viblo-embed/manual/parsers/index.js
+++ b/src/libs/viblo-embed/manual/parsers/index.js
@@ -2,10 +2,12 @@ import gist from './gist'
 import jsfiddle from './jsfiddle'
 import googleslide from './googleslide'
 import viblo from './viblo'
+import codepen from './codepen'
 
 export default {
     gist,
     jsfiddle,
     googleslide,
     viblo,
+    codepen,
 }

--- a/src/libs/viblo-embed/oembed/index.js
+++ b/src/libs/viblo-embed/oembed/index.js
@@ -31,6 +31,10 @@ const isOembed = (url, provider) => {
     return validRegex.test(url)
 }
 
+const isCodepenEmbed = (url) => {
+    return providers.codepen.test(url)
+}
+
 const fetchNoembed = (url) => new Promise((resolve, reject) => {
     requestNoembedHTML({ url, format: 'json' })
         .then((response) => {
@@ -73,5 +77,6 @@ const render = (url, provider = null) => new Promise((resolve, reject) => {
 
 export default {
     isOembed,
+    isCodepenEmbed,
     render
 }


### PR DESCRIPTION
Switch to manual embed strategy for codepen (instead of using currently broken codepen's oembed).

![Screenshot from 2021-03-02 15-59-18](https://user-images.githubusercontent.com/15942946/109624066-58b8ed00-7b70-11eb-9ba5-27fa259c048c.png)
