### PR TITLE
fix: codepen username regex

### DIFF
--- a/src/libs/viblo-embed/manual/parsers/codepen.js
+++ b/src/libs/viblo-embed/manual/parsers/codepen.js
@@ -1,5 +1,5 @@
 export default (url) => {
-    const regex = /^https?:\/\/codepen.io\/([a-zA-Z0-9]+)\/(pen|embed\/preview|embed)\/([a-zA-Z0-9]+)(.*)$/
+    const regex = /^https?:\/\/codepen.io\/([a-zA-Z0-9-_]+)\/(pen|embed\/preview|embed)\/([a-zA-Z0-9]+)(.*)$/
     const matches = url.match(regex)
 
     if (!matches) return


### PR DESCRIPTION
Modify regex expression of codepen manual embed strategy to allow usernames have characters `-` and `_`.